### PR TITLE
Fix blockhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
 
 [dependencies]
-bitcoin = { version= "0.23", features = [ "use-serde" ] }
+bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", features = [ "use-serde" ] }
 rand="0.7"
 rust-crypto = "0.2"
 serde = "1"
 serde_derive = "1"
 
 [dev-dependencies]
-bitcoin = { version= "0.23", features = [ "use-serde", "bitcoinconsensus" ] }
+bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", features = [ "use-serde", "bitcoinconsensus" ] }
 serde_json="1"
 hex = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
 
 [dependencies]
-bitcoin = { version= "0.23", features=["use-serde"]}
+bitcoin = { version= "0.23", features = [ "use-serde" ] }
 rand="0.7"
 rust-crypto = "0.2"
 serde = "1"
 serde_derive = "1"
 
 [dev-dependencies]
-bitcoin = { version= "0.23", features=["use-serde", "bitcoinconsensus"]}
+bitcoin = { version= "0.23", features = [ "use-serde", "bitcoinconsensus" ] }
 serde_json="1"
 hex = "0.3"

--- a/src/coins.rs
+++ b/src/coins.rs
@@ -325,7 +325,7 @@ mod test {
     use bitcoin::blockdata::script::Builder;
     use bitcoin::util::bip32::ExtendedPubKey;
     use bitcoin::{
-        network::constants::Network, Address, BitcoinHash, Block, BlockHeader, OutPoint,
+        network::constants::Network, Address, Block, BlockHeader, OutPoint,
         Transaction, TxIn, TxOut,
     };
 
@@ -406,10 +406,10 @@ mod test {
             .address
             .clone();
         let genesis = genesis_block(Network::Testnet);
-        let next = mine(&genesis.bitcoin_hash(), 1, miner);
+        let next = mine(&genesis.block_hash(), 1, miner);
         coins.process(&mut master, &next);
         assert_eq!(coins.confirmed_balance(), NEW_COINS);
-        coins.unwind_tip(&next.bitcoin_hash());
+        coins.unwind_tip(&next.block_hash());
         assert_eq!(coins.confirmed_balance(), 0);
     }
 }

--- a/src/proved.rs
+++ b/src/proved.rs
@@ -19,7 +19,7 @@
 //!
 
 use bitcoin::hashes::{sha256d, Hash, HashEngine};
-use bitcoin::{BitcoinHash, Block, Transaction};
+use bitcoin::{Block, Transaction};
 
 /// A confirmed transaction with its SPV proof
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -33,7 +33,7 @@ impl ProvedTransaction {
     pub fn new(block: &Block, txnr: usize) -> ProvedTransaction {
         let transaction = block.txdata[txnr].clone();
         ProvedTransaction {
-            block_hash: block.header.bitcoin_hash(),
+            block_hash: block.header.block_hash(),
             merkle_path: Self::compute_proof(txnr, block),
             transaction,
         }
@@ -134,7 +134,7 @@ mod test {
             let pt = ProvedTransaction {
                 transaction: tx.clone(),
                 merkle_path: proof,
-                block_hash: block.header.bitcoin_hash(),
+                block_hash: block.header.block_hash(),
             };
             assert_eq!(pt.merkle_root(), block.header.merkle_root);
         }


### PR DESCRIPTION
Removes support for `BitcoinHash` type which was obsoleted with rust-bitcoin/rust-bitcoin#385
