### PR TITLE
Adds support for Signet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
 
 [dependencies]
-bitcoin = { version= "0.23", features=["use-serde"]}
+bitcoin = { git = "https://github.com/kallewoof/rust-bitcoin.git", branch = "2019-07-signet", features=["use-serde"]}
 rand="0.7"
 rust-crypto = "0.2"
 serde = "1"
 serde_derive = "1"
 
 [dev-dependencies]
-bitcoin = { version= "0.23", features=["use-serde", "bitcoinconsensus"]}
+bitcoin = { git = "https://github.com/kallewoof/rust-bitcoin.git", branch = "2019-07-signet", features=["use-serde", "bitcoinconsensus"]}
 serde_json="1"
 hex = "0.3"

--- a/src/account.rs
+++ b/src/account.rs
@@ -307,6 +307,7 @@ impl Unlocker {
             Network::Bitcoin => 0,
             Network::Testnet => 1,
             Network::Regtest => 1,
+            Network::Signet => 1,
         };
         let by_coin_type = by_purpose.1.entry(coin_type).or_insert((
             self.context


### PR DESCRIPTION
Must be merged once 
* rust-bitcoin/rust-bitcoin#291 will be merged into the upstream rust-bitcoin library
* https://github.com/rust-bitcoin/rust-wallet/pull/16 merged to fix the compilation failure

For signet, we use the same coin type as for other testnets (which equals 1).