### PR TITLE
Just a few tweaks to make it compatible with rust-bitcoin 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-wallet"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Tamas Blummer <tamas.blummer@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/rust-bitcoin/rust-wallet/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ keywords = [ "crypto", "bitcoin" ]
 readme = "README.md"
 
 [dependencies]
-bitcoin = { version= "0.23", features=["use-serde"]}
+bitcoin = { version= "0.26", features=["use-serde"]}
 rand="0.7"
 rust-crypto = "0.2"
 serde = "1"
 serde_derive = "1"
 
 [dev-dependencies]
-bitcoin = { version= "0.23", features=["use-serde", "bitcoinconsensus"]}
+bitcoin = { version= "0.26", features=["use-serde", "bitcoinconsensus"]}
 serde_json="1"
 hex = "0.3"

--- a/src/account.rs
+++ b/src/account.rs
@@ -303,11 +303,7 @@ impl Unlocker {
             )?,
             HashMap::new(),
         ));
-        let coin_type = match self.network {
-            Network::Bitcoin => 0,
-            Network::Testnet => 1,
-            Network::Regtest => 1,
-        };
+        let coin_type = if self.network == Network::Bitcoin { 0 } else { 1 };
         let by_coin_type = by_purpose.1.entry(coin_type).or_insert((
             self.context
                 .private_child(&by_purpose.0, ChildNumber::Hardened { index: coin_type })?,
@@ -790,8 +786,8 @@ impl InstantiatedKey {
         let script_code = scripter(&public, csv);
         let address = match address_type {
             AccountAddressType::P2PKH => Address::p2pkh(&public, network),
-            AccountAddressType::P2SHWPKH => Address::p2shwpkh(&public, network),
-            AccountAddressType::P2WPKH => Address::p2wpkh(&public, network),
+            AccountAddressType::P2SHWPKH => Address::p2shwpkh(&public, network)?,
+            AccountAddressType::P2WPKH => Address::p2wpkh(&public, network)?,
             AccountAddressType::P2WSH(_) => Address::p2wsh(&script_code, network),
         };
         Ok(InstantiatedKey {

--- a/src/coins.rs
+++ b/src/coins.rs
@@ -325,7 +325,7 @@ mod test {
     use bitcoin::blockdata::script::Builder;
     use bitcoin::util::bip32::ExtendedPubKey;
     use bitcoin::{
-        network::constants::Network, Address, BitcoinHash, Block, BlockHeader, OutPoint,
+        network::constants::Network, Address, Block, BlockHeader, OutPoint,
         Transaction, TxIn, TxOut,
     };
 
@@ -406,10 +406,10 @@ mod test {
             .address
             .clone();
         let genesis = genesis_block(Network::Testnet);
-        let next = mine(&genesis.bitcoin_hash(), 1, miner);
+        let next = mine(&genesis.block_hash(), 1, miner);
         coins.process(&mut master, &next);
         assert_eq!(coins.confirmed_balance(), NEW_COINS);
-        coins.unwind_tip(&next.bitcoin_hash());
+        coins.unwind_tip(&next.block_hash());
         assert_eq!(coins.confirmed_balance(), 0);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ use crypto::symmetriccipher;
 
 /// An error class to offer a unified error interface upstream
 pub enum Error {
+    /// address error
+    Address(bitcoin::util::address::Error),
     /// Unsupported
     Unsupported(&'static str),
     /// mnemonic related error
@@ -51,6 +53,7 @@ impl error::Error for Error {
 
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
+            Error::Address(ref err) => Some(err),
             Error::Network => None,
             Error::Passphrase => None,
             Error::Unsupported(_) => None,
@@ -68,6 +71,7 @@ impl fmt::Display for Error {
         match *self {
             // Both underlying errors already impl `Display`, so we defer to
             // their implementations.
+            Error::Address(ref err) => write!(f, "invalid address: {}", err),
             Error::Passphrase => write!(f, "wrong passphrase"),
             Error::Network => write!(f, "wrong network"),
             Error::Unsupported(ref s) => write!(f, "Unsupported: {}", s),
@@ -125,5 +129,11 @@ impl convert::From<symmetriccipher::SymmetricCipherError> for Error {
 impl convert::From<bitcoin::secp256k1::Error> for Error {
     fn from(err: bitcoin::secp256k1::Error) -> Error {
         Error::SecpError(err)
+    }
+}
+
+impl convert::From<bitcoin::util::address::Error> for Error {
+    fn from(err: bitcoin::util::address::Error) -> Error {
+        Error::Address(err)
     }
 }

--- a/src/proved.rs
+++ b/src/proved.rs
@@ -19,21 +19,21 @@
 //!
 
 use bitcoin::hashes::{sha256d, Hash, HashEngine};
-use bitcoin::{BitcoinHash, Block, Transaction};
+use bitcoin::{BlockHash, Block, Transaction};
 
 /// A confirmed transaction with its SPV proof
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct ProvedTransaction {
     transaction: Transaction,
     merkle_path: Vec<(bool, sha256d::Hash)>,
-    block_hash: bitcoin::BlockHash,
+    block_hash: BlockHash,
 }
 
 impl ProvedTransaction {
     pub fn new(block: &Block, txnr: usize) -> ProvedTransaction {
         let transaction = block.txdata[txnr].clone();
         ProvedTransaction {
-            block_hash: block.header.bitcoin_hash(),
+            block_hash: block.header.block_hash(),
             merkle_path: Self::compute_proof(txnr, block),
             transaction,
         }
@@ -43,7 +43,7 @@ impl ProvedTransaction {
         self.transaction.clone()
     }
 
-    pub fn get_block_hash(&self) -> &bitcoin::BlockHash {
+    pub fn get_block_hash(&self) -> &BlockHash {
         &self.block_hash
     }
 
@@ -134,7 +134,7 @@ mod test {
             let pt = ProvedTransaction {
                 transaction: tx.clone(),
                 merkle_path: proof,
-                block_hash: block.header.bitcoin_hash(),
+                block_hash: block.header.block_hash(),
             };
             assert_eq!(pt.merkle_root(), block.header.merkle_root);
         }


### PR DESCRIPTION
Hi,

This PR makes as little as possible to update the rust-bitcoin version.

I noticed there's a bunch of clippy lints and some further refactorings to move from the deprecated 'SigHashComponents'

https://docs.rs/bitcoin/0.26.0/bitcoin/util/bip143/struct.SighashComponents.html

I can send PR's for those unless there's already someone working on it.

